### PR TITLE
MVP #5: Influence cluster graph + repeated amplification detection

### DIFF
--- a/benchmarks/datasets/influence-fixture-001-repeated-amplification.json
+++ b/benchmarks/datasets/influence-fixture-001-repeated-amplification.json
@@ -1,0 +1,83 @@
+{
+  "description": "Synthetic propagation fixture for repeated amplification pathway detection (MVP #5)",
+  "state_seed_accounts": ["state_media_alpha", "state_media_beta"],
+  "influencer_seed_accounts": ["influencer_echo", "influencer_vector"],
+  "events": [
+    {
+      "id": "e1",
+      "content_id": "c1",
+      "account": "state_media_alpha",
+      "timestamp": "2026-03-30T12:00:00Z",
+      "uncertainty": "verified"
+    },
+    {
+      "id": "e2",
+      "content_id": "c1",
+      "account": "influencer_echo",
+      "timestamp": "2026-03-30T12:05:00Z",
+      "amplified_from_event_id": "e1",
+      "uncertainty": "likely"
+    },
+    {
+      "id": "e3",
+      "content_id": "c1",
+      "account": "community_forum_1",
+      "timestamp": "2026-03-30T12:07:00Z",
+      "amplified_from_event_id": "e2",
+      "uncertainty": "unknown"
+    },
+    {
+      "id": "e4",
+      "content_id": "c2",
+      "account": "state_media_alpha",
+      "timestamp": "2026-03-30T14:00:00Z",
+      "uncertainty": "verified"
+    },
+    {
+      "id": "e5",
+      "content_id": "c2",
+      "account": "influencer_echo",
+      "timestamp": "2026-03-30T14:06:00Z",
+      "amplified_from_event_id": "e4",
+      "uncertainty": "likely"
+    },
+    {
+      "id": "e6",
+      "content_id": "c2",
+      "account": "community_forum_1",
+      "timestamp": "2026-03-30T14:10:00Z",
+      "amplified_from_event_id": "e5",
+      "uncertainty": "disputed"
+    },
+    {
+      "id": "e7",
+      "content_id": "c3",
+      "account": "state_media_beta",
+      "timestamp": "2026-03-30T15:00:00Z",
+      "uncertainty": "likely"
+    },
+    {
+      "id": "e8",
+      "content_id": "c3",
+      "account": "influencer_vector",
+      "timestamp": "2026-03-30T15:04:00Z",
+      "amplified_from_event_id": "e7",
+      "uncertainty": "likely"
+    },
+    {
+      "id": "e9",
+      "content_id": "c4",
+      "account": "state_media_alpha",
+      "timestamp": "2026-03-30T16:00:00Z",
+      "uncertainty": "verified"
+    },
+    {
+      "id": "e10",
+      "content_id": "c4",
+      "account": "influencer_echo",
+      "timestamp": "2026-03-30T16:03:00Z",
+      "amplified_from_event_id": "e9",
+      "uncertainty": "likely"
+    }
+  ]
+}

--- a/tools/provenance/influence_graph.py
+++ b/tools/provenance/influence_graph.py
@@ -1,0 +1,242 @@
+"""Influence cluster graph + repeated amplification path detection.
+
+Stdlib-only implementation for MVP #5.
+"""
+
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+from datetime import datetime
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
+
+
+def _parse_ts(value: str) -> datetime:
+    if value.endswith("Z"):
+        value = value[:-1] + "+00:00"
+    return datetime.fromisoformat(value)
+
+
+def _safe_parse_ts(value: str) -> Optional[datetime]:
+    try:
+        return _parse_ts(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _duplicate_event_ids(events: Sequence[Dict[str, Any]]) -> List[str]:
+    counts = Counter(event.get("id") for event in events if event.get("id"))
+    return sorted(event_id for event_id, count in counts.items() if count > 1)
+
+
+def build_influence_graph(
+    events: Iterable[Dict[str, Any]],
+    state_seed_accounts: Optional[Sequence[str]] = None,
+    influencer_seed_accounts: Optional[Sequence[str]] = None,
+) -> Dict[str, Any]:
+    """Build node/edge artifacts and repeated amplification pathway metrics."""
+
+    events_list = list(events)
+    duplicate_ids = _duplicate_event_ids(events_list)
+    if duplicate_ids:
+        return {
+            "graph": {"nodes": [], "edges": []},
+            "pathways": {"repeated_pathways": []},
+            "uncertainty": {
+                "status": "error",
+                "code": "duplicate_event_ids",
+                "message": "Duplicate event IDs detected; influence graph not constructed.",
+                "duplicate_event_ids": duplicate_ids,
+            },
+        }
+
+    events_by_id: Dict[str, Dict[str, Any]] = {}
+    ordered_events: List[Dict[str, Any]] = []
+
+    for event in events_list:
+        event_copy = dict(event)
+        event_copy.setdefault("uncertainty", "unknown")
+        ordered_events.append(event_copy)
+        events_by_id[event_copy["id"]] = event_copy
+
+    state_seeds = set(state_seed_accounts or [])
+    influencer_seeds = set(influencer_seed_accounts or [])
+
+    nodes: Dict[str, Dict[str, Any]] = {}
+    edges: List[Dict[str, Any]] = []
+    invalid_timestamp_event_ids: set[str] = set()
+
+    def ensure_node(account: str) -> Dict[str, Any]:
+        if account not in nodes:
+            tags = []
+            if account in state_seeds:
+                tags.append("state_affiliated_seed")
+            if account in influencer_seeds:
+                tags.append("influencer_seed")
+            nodes[account] = {
+                "id": account,
+                "account": account,
+                "seed_tags": tags,
+                "event_count": 0,
+            }
+        return nodes[account]
+
+    for event in ordered_events:
+        account = event["account"]
+        ensure_node(account)["event_count"] += 1
+
+    for event in ordered_events:
+        parent_id = event.get("amplified_from_event_id")
+        if not parent_id:
+            continue
+        parent = events_by_id.get(parent_id)
+        if not parent:
+            continue
+
+        child_ts = _safe_parse_ts(event["timestamp"])
+        parent_ts = _safe_parse_ts(parent["timestamp"])
+        if child_ts is None:
+            invalid_timestamp_event_ids.add(event["id"])
+            event["uncertainty"] = "invalid-timestamp"
+            continue
+        if parent_ts is None:
+            invalid_timestamp_event_ids.add(parent["id"])
+            parent["uncertainty"] = "invalid-timestamp"
+            continue
+
+        lag_seconds = max(0.0, (child_ts - parent_ts).total_seconds())
+
+        parent_account = parent["account"]
+        child_account = event["account"]
+        ensure_node(parent_account)
+        ensure_node(child_account)
+
+        edges.append(
+            {
+                "from": parent_account,
+                "to": child_account,
+                "parent_event_id": parent_id,
+                "child_event_id": event["id"],
+                "content_id": event.get("content_id") or parent.get("content_id"),
+                "lag_seconds": lag_seconds,
+                "direct": True,
+                "uncertainty": {
+                    "parent": parent.get("uncertainty", "unknown"),
+                    "child": event.get("uncertainty", "unknown"),
+                },
+            }
+        )
+
+    pathways = detect_repeated_amplification_pathways(ordered_events, events_by_id)
+
+    uncertainty: Dict[str, Any]
+    if invalid_timestamp_event_ids:
+        uncertainty = {
+            "status": "uncertain",
+            "code": "invalid_timestamps",
+            "message": "One or more events had malformed timestamps; related edges/pathways were skipped.",
+            "invalid_timestamp_event_ids": sorted(invalid_timestamp_event_ids),
+        }
+    else:
+        uncertainty = {"status": "ok"}
+
+    return {
+        "graph": {
+            "nodes": sorted(nodes.values(), key=lambda n: n["id"]),
+            "edges": edges,
+        },
+        "pathways": pathways,
+        "uncertainty": uncertainty,
+    }
+
+
+def detect_repeated_amplification_pathways(
+    ordered_events: Sequence[Dict[str, Any]],
+    events_by_id: Dict[str, Dict[str, Any]],
+) -> Dict[str, Any]:
+    """Detect repeated account-to-account amplification pathways + basic metrics."""
+
+    path_counter: Counter[Tuple[str, ...]] = Counter()
+    path_metrics: Dict[Tuple[str, ...], Dict[str, Any]] = defaultdict(
+        lambda: {
+            "frequency": 0,
+            "direct_occurrences": 0,
+            "indirect_occurrences": 0,
+            "lags": [],
+            "uncertainty_labels": Counter(),
+            "content_ids": Counter(),
+        }
+    )
+
+    for event in ordered_events:
+        chain_events: List[Dict[str, Any]] = [event]
+        current = event
+        visited_event_ids = {event.get("id")}
+
+        while current.get("amplified_from_event_id"):
+            parent_id = current["amplified_from_event_id"]
+            parent = events_by_id.get(parent_id)
+            if not parent:
+                break
+            if parent_id in visited_event_ids:
+                chain_events.append(
+                    {
+                        "id": parent_id,
+                        "account": parent.get("account", "unknown"),
+                        "timestamp": parent.get("timestamp", event.get("timestamp", "")),
+                        "uncertainty": "cycle-detected",
+                    }
+                )
+                break
+            chain_events.append(parent)
+            visited_event_ids.add(parent_id)
+            current = parent
+
+        chain_events.reverse()
+        account_path = tuple(item["account"] for item in chain_events)
+        if len(account_path) < 2:
+            continue
+
+        root_ts = _safe_parse_ts(chain_events[0]["timestamp"])
+        leaf_ts = _safe_parse_ts(chain_events[-1]["timestamp"])
+        if root_ts is None or leaf_ts is None:
+            for item in chain_events:
+                item.setdefault("uncertainty", "invalid-timestamp")
+            continue
+
+        total_lag = max(0.0, (leaf_ts - root_ts).total_seconds())
+
+        path_counter[account_path] += 1
+        metrics = path_metrics[account_path]
+        metrics["frequency"] += 1
+        if len(account_path) == 2:
+            metrics["direct_occurrences"] += 1
+        else:
+            metrics["indirect_occurrences"] += 1
+        metrics["lags"].append(total_lag)
+
+        for item in chain_events:
+            metrics["uncertainty_labels"][item.get("uncertainty", "unknown")] += 1
+        content_id = event.get("content_id")
+        if content_id:
+            metrics["content_ids"][content_id] += 1
+
+    repeated = []
+    for path, frequency in path_counter.items():
+        if frequency < 2:
+            continue
+        m = path_metrics[path]
+        avg_lag_seconds = (sum(m["lags"]) / len(m["lags"])) if m["lags"] else 0.0
+        repeated.append(
+            {
+                "path": list(path),
+                "frequency": m["frequency"],
+                "avg_lag_seconds": avg_lag_seconds,
+                "direct_occurrences": m["direct_occurrences"],
+                "indirect_occurrences": m["indirect_occurrences"],
+                "content_ids": dict(m["content_ids"]),
+                "uncertainty_labels": dict(m["uncertainty_labels"]),
+            }
+        )
+
+    repeated.sort(key=lambda item: (-item["frequency"], item["path"]))
+    return {"repeated_pathways": repeated}

--- a/tools/provenance/test_influence_graph.py
+++ b/tools/provenance/test_influence_graph.py
@@ -1,0 +1,126 @@
+import json
+import unittest
+from pathlib import Path
+
+from tools.provenance.influence_graph import build_influence_graph
+
+
+class InfluenceGraphTests(unittest.TestCase):
+    def setUp(self):
+        fixture_path = (
+            Path(__file__).resolve().parents[2]
+            / "benchmarks"
+            / "datasets"
+            / "influence-fixture-001-repeated-amplification.json"
+        )
+        with fixture_path.open("r", encoding="utf-8") as f:
+            self.fixture = json.load(f)
+
+    def _run_fixture(self):
+        return build_influence_graph(
+            self.fixture["events"],
+            state_seed_accounts=self.fixture["state_seed_accounts"],
+            influencer_seed_accounts=self.fixture["influencer_seed_accounts"],
+        )
+
+    def test_mvp5_tc01_tc02_tc03_tc04_tc05(self):
+        result = self._run_fixture()
+        self.assertIn("graph", result)
+        self.assertIn("nodes", result["graph"])
+        self.assertIn("edges", result["graph"])
+        self.assertGreaterEqual(len(result["graph"]["nodes"]), 1)
+        self.assertGreaterEqual(len(result["graph"]["edges"]), 1)
+
+        nodes = {node["id"]: node for node in result["graph"]["nodes"]}
+        self.assertIn("state_affiliated_seed", nodes["state_media_alpha"]["seed_tags"])
+        self.assertIn("influencer_seed", nodes["influencer_echo"]["seed_tags"])
+
+        repeated = result["pathways"]["repeated_pathways"]
+        matching = [
+            item
+            for item in repeated
+            if item["path"]
+            == ["state_media_alpha", "influencer_echo", "community_forum_1"]
+        ]
+        self.assertEqual(len(matching), 1)
+
+        pathway = matching[0]
+        self.assertEqual(pathway["frequency"], 2)
+        self.assertEqual(pathway["direct_occurrences"], 0)
+        self.assertEqual(pathway["indirect_occurrences"], 2)
+        self.assertGreater(pathway["avg_lag_seconds"], 0)
+        self.assertIn("verified", pathway["uncertainty_labels"])
+        self.assertIn("likely", pathway["uncertainty_labels"])
+
+    def test_mvp5_tc06_rank_stability(self):
+        first = self._run_fixture()
+        second = self._run_fixture()
+        self.assertEqual(
+            first["pathways"]["repeated_pathways"],
+            second["pathways"]["repeated_pathways"],
+        )
+
+    def test_mvp5_tc09_cyclic_graph_does_not_loop(self):
+        cycle_events = [
+            {
+                "id": "c1",
+                "content_id": "cc1",
+                "account": "a",
+                "timestamp": "2026-03-30T12:00:00Z",
+                "amplified_from_event_id": "c2",
+                "uncertainty": "likely",
+            },
+            {
+                "id": "c2",
+                "content_id": "cc1",
+                "account": "b",
+                "timestamp": "2026-03-30T12:01:00Z",
+                "amplified_from_event_id": "c1",
+                "uncertainty": "likely",
+            },
+        ]
+
+        result = build_influence_graph(cycle_events)
+        self.assertIn("repeated_pathways", result["pathways"])
+        self.assertEqual(result["pathways"]["repeated_pathways"], [])
+
+    def test_duplicate_event_ids_rejected_deterministically(self):
+        events = [
+            {"id": "evt-1", "account": "alpha", "timestamp": "2024-01-01T00:00:00Z"},
+            {
+                "id": "evt-1",
+                "account": "beta",
+                "timestamp": "2024-01-01T00:05:00Z",
+                "amplified_from_event_id": "evt-1",
+            },
+            {"id": "evt-2", "account": "gamma", "timestamp": "2024-01-01T00:06:00Z"},
+            {"id": "evt-2", "account": "delta", "timestamp": "2024-01-01T00:07:00Z"},
+        ]
+
+        result = build_influence_graph(events)
+        self.assertEqual(result["uncertainty"]["status"], "error")
+        self.assertEqual(result["uncertainty"]["code"], "duplicate_event_ids")
+        self.assertEqual(result["uncertainty"]["duplicate_event_ids"], ["evt-1", "evt-2"])
+        self.assertEqual(result["graph"]["nodes"], [])
+        self.assertEqual(result["graph"]["edges"], [])
+
+    def test_malformed_timestamp_marks_uncertainty_without_exception(self):
+        events = [
+            {"id": "root", "account": "origin", "timestamp": "2024-01-01T00:00:00Z"},
+            {
+                "id": "child-bad-ts",
+                "account": "amplifier",
+                "timestamp": "definitely-not-an-iso-timestamp",
+                "amplified_from_event_id": "root",
+            },
+        ]
+
+        result = build_influence_graph(events)
+        self.assertEqual(result["uncertainty"]["status"], "uncertain")
+        self.assertEqual(result["uncertainty"]["code"], "invalid_timestamps")
+        self.assertEqual(result["uncertainty"]["invalid_timestamp_event_ids"], ["child-bad-ts"])
+        self.assertEqual(result["graph"]["edges"], [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #5

## Summary
- harden stdlib-only influence graph implementation at `tools/provenance/influence_graph.py`
- emit graph artifact (`nodes` + `edges`) from propagation events
- detect repeated amplification pathways and compute metrics:
  - frequency
  - lag
  - direct vs indirect counts
- support seed tagging for state-affiliated and influencer accounts
- preserve uncertainty labels in edge/pathway outputs
- add/expand fixture + tests:
  - `benchmarks/datasets/influence-fixture-001-repeated-amplification.json`
  - `tools/provenance/test_influence_graph.py`

## MVP #5 checklist (executable)
- [x] **MVP5-TC01 (P0):** graph artifact emission (`nodes`/`edges` with required fields)
- [x] **MVP5-TC02 (P0):** repeated amplification pathway detection in fixture data
- [x] **MVP5-TC03 (P0):** pathway frequency/lag/direct-vs-indirect metrics computed
- [x] **MVP5-TC04 (P0):** seed tagging for state-affiliated and influencer nodes
- [x] **MVP5-TC05 (P0):** uncertainty propagation preserved in edges/pathways
- [x] **MVP5-TC06 (P1):** deterministic rank stability for top pathways
- [x] **MVP5-TC09 (P2):** cyclic graph handling without infinite traversal

## Adversarial fix wave (PR blocker resolution)
- ✅ Reject duplicate event IDs deterministically (no silent overwrite of lineage graph state)
  - returns structured uncertainty error: `code=duplicate_event_ids` with sorted `duplicate_event_ids`
- ✅ Handle malformed timestamps gracefully (no uncaught exception)
  - skips affected edge/pathway computations
  - returns structured uncertainty marker: `code=invalid_timestamps` with `invalid_timestamp_event_ids`
- ✅ Added adversarial tests:
  - `test_duplicate_event_ids_rejected_deterministically`
  - `test_malformed_timestamp_marks_uncertainty_without_exception`

## Test evidence
```bash
python3 -m unittest -v tools/provenance/test_influence_graph.py
```

Output summary:
- Ran 5 tests
- OK (5 passed, 0 failed)
